### PR TITLE
fix: using sprintln instead of sprint

### DIFF
--- a/log.go
+++ b/log.go
@@ -194,7 +194,7 @@ func (l *Logger) doPrint(level int, ctx Context, format string, v ...interface{}
 
 	var formatString string
 	if strings.EqualFold("", format) {
-		formatString = fmt.Sprint(v...)
+		formatString = fmt.Sprintln(v...)
 	} else {
 		formatString = fmt.Sprintf(format, v...)
 	}

--- a/log.go
+++ b/log.go
@@ -48,6 +48,7 @@ func (l *Logger) releaseEntry(e *Entry) {
 
 var once sync.Once
 var logger *Logger
+var file *os.File
 
 // Log is one glocal logger which can be used in any packages
 // var Log = NewLogger(os.Stdout, INFO)
@@ -76,6 +77,28 @@ func NewLogger(writer io.Writer, level, caller int) *Logger {
 // NewDefaultLogger returns a instance of Logger with default configurations
 func NewDefaultLogger() {
 	logger = NewLogger(os.Stdout, LogLevelDefault, CallPathDefault)
+}
+
+const DefaultLogFile = "./access.log"
+
+func SetDefaultLogFile() {
+	SetLogFile(DefaultLogFile)
+}
+
+func SetLogFile(path string) {
+	f, err := os.Open(path)
+	if err != nil {
+		f, err := os.Create(path)
+		if err != nil {
+			panic(err)
+		} else {
+			file = f
+		}
+	} else {
+		file = f
+	}
+
+	logger.Writer = file
 }
 
 func SetFormatter(f Formatter) {
@@ -200,6 +223,7 @@ func (l *Logger) doPrint(level int, ctx Context, format string, v ...interface{}
 	}
 	fields.Msg = formatString
 
+	// this is core print functions
 	msg := l.formatter.Print(fields, ctx)
 	fmt.Fprintln(l.Writer, msg)
 }

--- a/log_test.go
+++ b/log_test.go
@@ -99,3 +99,9 @@ func Benchmark_Infof(b *testing.B) {
 		logger.Infof("key %s", "value")
 	}
 }
+
+func Test_LogFile(t *testing.T) {
+	NewDefaultLogger()
+	SetLogFile("./test.log")
+	logger.Infoln("a", "b")
+}

--- a/log_test.go
+++ b/log_test.go
@@ -85,8 +85,9 @@ func Test_FormatterLogger(t *testing.T) {
 func Test_DefaultLogger(t *testing.T) {
 	NewDefaultLogger()
 	SetFormatter(&TextFormatter{})
-	logger.SetLevelByName("WaRN")
-	printall(logger.Level)
+	logger.SetLevelByName("InFo")
+	//printall(logger.Level)
+	logger.Infoln("a", "b")
 }
 
 func Benchmark_Infof(b *testing.B) {


### PR DESCRIPTION
fix: using sprintln instead of sprint