### PR TITLE
refactor: introduce doPrintln and using string as param

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -36,9 +36,9 @@ func (e *Entry) WithContext(ctx Context) *Entry {
 }
 
 // Traceln print trace level logs in a line
-func (e *Entry) Traceln(v ...interface{}) {
+func (e *Entry) Traceln(msg string) {
 	if LogLevelTrace >= e.logger.Level {
-		e.logger.println(LogLevelTrace, e.Context, v...)
+		e.logger.println(LogLevelTrace, e.Context, msg)
 	}
 }
 
@@ -50,9 +50,9 @@ func (e *Entry) Tracef(format string, v ...interface{}) {
 }
 
 // Debugln print debug level logs in a line
-func (e *Entry) Debugln(v ...interface{}) {
+func (e *Entry) Debugln(msg string) {
 	if LogLevelDebug >= e.logger.Level {
-		e.logger.println(LogLevelDebug, e.Context, v...)
+		e.logger.println(LogLevelDebug, e.Context, msg)
 	}
 }
 
@@ -64,9 +64,9 @@ func (e *Entry) Debugf(format string, v ...interface{}) {
 }
 
 // Infoln print info level logs in a line
-func (e *Entry) Infoln(v ...interface{}) {
+func (e *Entry) Infoln(msg string) {
 	if LogLevelInfo >= e.logger.Level {
-		e.logger.println(LogLevelInfo, e.Context, v...)
+		e.logger.println(LogLevelInfo, e.Context, msg)
 	}
 }
 
@@ -78,9 +78,9 @@ func (e *Entry) Infof(format string, v ...interface{}) {
 }
 
 // Warnln print warn level logs in a line
-func (e *Entry) Warnln(v ...interface{}) {
+func (e *Entry) Warnln(msg string) {
 	if LogLevelWarn >= e.logger.Level {
-		e.logger.println(LogLevelWarn, e.Context, v...)
+		e.logger.println(LogLevelWarn, e.Context, msg)
 	}
 }
 
@@ -92,9 +92,9 @@ func (e *Entry) Warnf(format string, v ...interface{}) {
 }
 
 // Errorln print error level logs in a line
-func (e *Entry) Errorln(v ...interface{}) {
+func (e *Entry) Errorln(msg string) {
 	if LogLevelError >= e.logger.Level {
-		e.logger.println(LogLevelError, e.Context, v...)
+		e.logger.println(LogLevelError, e.Context, msg)
 	}
 }
 
@@ -106,9 +106,9 @@ func (e *Entry) Errorf(format string, v ...interface{}) {
 }
 
 // Fatalln print fatal level logs in a line
-func (e *Entry) Fatalln(v ...interface{}) {
+func (e *Entry) Fatalln(msg string) {
 	if LogLevelFatal >= e.logger.Level {
-		e.logger.println(LogLevelFatal, e.Context, v...)
+		e.logger.println(LogLevelFatal, e.Context, msg)
 		os.Exit(1)
 	}
 }

--- a/log.go
+++ b/log.go
@@ -139,8 +139,8 @@ func SetSink(s Sink) {
 */
 
 // Traceln print trace level logs in a line
-func Traceln(v ...interface{}) {
-	logger.Traceln(v...)
+func Traceln(msg string) {
+	logger.Traceln(msg)
 }
 
 // Tracef print trace level logs in a specific format
@@ -149,8 +149,8 @@ func Tracef(format string, v ...interface{}) {
 }
 
 // Debugln print debug level logs in a line
-func Debugln(v ...interface{}) {
-	logger.Debugln(v...)
+func Debugln(msg string) {
+	logger.Debugln(msg)
 }
 
 // Debugf print debug level logs in a specific format
@@ -159,8 +159,8 @@ func Debugf(format string, v ...interface{}) {
 }
 
 // Infoln print info level logs in a line
-func Infoln(v ...interface{}) {
-	logger.Infoln(v...)
+func Infoln(msg string) {
+	logger.Infoln(msg)
 }
 
 // Infof print info level logs in a specific format
@@ -169,8 +169,8 @@ func Infof(format string, v ...interface{}) {
 }
 
 // Warnln print warn level logs in a line
-func Warnln(v ...interface{}) {
-	logger.Warnln(v...)
+func Warnln(msg string) {
+	logger.Warnln(msg)
 }
 
 // Warnf print warn level logs in a specific format
@@ -179,8 +179,8 @@ func Warnf(format string, v ...interface{}) {
 }
 
 // Errorln print error level logs in a line
-func Errorln(v ...interface{}) {
-	logger.Errorln(v...)
+func Errorln(msg string) {
+	logger.Errorln(msg)
 }
 
 // Errorf print error level logs in a specific format
@@ -189,8 +189,8 @@ func Errorf(format string, v ...interface{}) {
 }
 
 // Fatalln print fatal level logs in a line
-func Fatalln(v ...interface{}) {
-	logger.Fatalln(v...)
+func Fatalln(msg string) {
+	logger.Fatalln(msg)
 }
 
 // Fatalf print fatal level logs in a specific format

--- a/logger.go
+++ b/logger.go
@@ -99,7 +99,7 @@ func (l *Logger) SetCallPath(callPath int) {
 }
 
 func (l *Logger) doPrint(level int, ctx Context, format string, v ...interface{}) {
-	fields := Fields{
+	fields := &Fields{
 		Timestamp: getTimestamp(),
 		Level:     getLogLevel(level),
 		Msg:       formattedMessage(format, v...),
@@ -108,15 +108,29 @@ func (l *Logger) doPrint(level int, ctx Context, format string, v ...interface{}
 	fields.File, fields.Func, fields.Line = getFuncInfo(l.CallPath)
 
 	// this is core print functions
-	msg := l.formatter.Print(&fields, ctx)
+	msg := l.formatter.Print(fields, ctx)
 	fmt.Fprintln(l.Writer, msg)
 }
 
-func (l *Logger) println(level int, ctx Context, v ...interface{}) {
+func (l *Logger) doPrintln(level int, ctx Context, format string, msg string) {
+	fields := &Fields{
+		Timestamp: getTimestamp(),
+		Level:     getLogLevel(level),
+		Msg:       msg,
+	}
+
+	fields.File, fields.Func, fields.Line = getFuncInfo(l.CallPath)
+
+	// this is core print functions
+	data := l.formatter.Print(fields, ctx)
+	fmt.Fprintln(l.Writer, data)
+}
+
+func (l *Logger) println(level int, ctx Context, msg string) {
 	if l.Async {
-		go l.doPrint(level, ctx, "", v...)
+		go l.doPrintln(level, ctx, "", msg)
 	} else {
-		l.doPrint(level, ctx, "", v...)
+		l.doPrintln(level, ctx, "", msg)
 	}
 }
 
@@ -131,9 +145,9 @@ func (l *Logger) printf(level int, ctx Context, format string, v ...interface{})
 type Context map[string]string
 
 // Traceln print trace level logs in a line
-func (l *Logger) Traceln(v ...interface{}) {
+func (l *Logger) Traceln(msg string) {
 	if LogLevelTrace >= logger.Level {
-		l.println(LogLevelTrace, Context{}, v...)
+		l.println(LogLevelTrace, Context{}, msg)
 	}
 }
 
@@ -145,9 +159,9 @@ func (l *Logger) Tracef(format string, v ...interface{}) {
 }
 
 // Debugln print debug level logs in a line
-func (l *Logger) Debugln(v ...interface{}) {
+func (l *Logger) Debugln(msg string) {
 	if LogLevelDebug >= logger.Level {
-		l.println(LogLevelDebug, Context{}, v...)
+		l.println(LogLevelDebug, Context{}, msg)
 	}
 }
 
@@ -159,9 +173,9 @@ func (l *Logger) Debugf(format string, v ...interface{}) {
 }
 
 // Infoln print info level logs in a line
-func (l *Logger) Infoln(v ...interface{}) {
+func (l *Logger) Infoln(msg string) {
 	if LogLevelInfo >= logger.Level {
-		l.println(LogLevelInfo, Context{}, v...)
+		l.println(LogLevelInfo, Context{}, msg)
 	}
 }
 
@@ -173,9 +187,9 @@ func (l *Logger) Infof(format string, v ...interface{}) {
 }
 
 // Warnln print warn level logs in a line
-func (l *Logger) Warnln(v ...interface{}) {
+func (l *Logger) Warnln(msg string) {
 	if LogLevelWarn >= logger.Level {
-		l.println(LogLevelWarn, Context{}, v...)
+		l.println(LogLevelWarn, Context{}, msg)
 	}
 }
 
@@ -187,9 +201,9 @@ func (l *Logger) Warnf(format string, v ...interface{}) {
 }
 
 // Errorln print error level logs in a line
-func (l *Logger) Errorln(v ...interface{}) {
+func (l *Logger) Errorln(msg string) {
 	if LogLevelError >= logger.Level {
-		l.println(LogLevelError, Context{}, v...)
+		l.println(LogLevelError, Context{}, msg)
 	}
 }
 
@@ -201,9 +215,9 @@ func (l *Logger) Errorf(format string, v ...interface{}) {
 }
 
 // Fatalln print fatal level logs in a line
-func (l *Logger) Fatalln(v ...interface{}) {
+func (l *Logger) Fatalln(msg string) {
 	if LogLevelFatal >= logger.Level {
-		l.println(LogLevelFatal, Context{}, v...)
+		l.println(LogLevelFatal, Context{}, msg)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Performance improved: 

```shell
before:

BenchmarkEvent/Mlog-12            	 1941562	       625.4 ns/op	    1106 B/op	      19 allocs/op

after:
BenchmarkEvent/Mlog-12            	 2094327	       580.2 ns/op	    1009 B/op	      16 allocs/op
```
