### PR TITLE
refactor: merge print and reduce unneccessary string generation

### DIFF
--- a/entry.go
+++ b/entry.go
@@ -38,77 +38,77 @@ func (e *Entry) WithContext(ctx Context) *Entry {
 // Traceln print trace level logs in a line
 func (e *Entry) Traceln(msg string) {
 	if LogLevelTrace >= e.logger.Level {
-		e.logger.println(LogLevelTrace, e.Context, msg)
+		e.logger.println(e.Context, msg)
 	}
 }
 
 // Tracef print trace level logs in a specific format
 func (e *Entry) Tracef(format string, v ...interface{}) {
 	if LogLevelTrace >= e.logger.Level {
-		e.logger.printf(LogLevelTrace, e.Context, format, v...)
+		e.logger.printf(e.logger.Level, e.Context, format, v...)
 	}
 }
 
 // Debugln print debug level logs in a line
 func (e *Entry) Debugln(msg string) {
 	if LogLevelDebug >= e.logger.Level {
-		e.logger.println(LogLevelDebug, e.Context, msg)
+		e.logger.println(e.Context, msg)
 	}
 }
 
 // Debugf print debug level logs in a specific format
 func (e *Entry) Debugf(format string, v ...interface{}) {
 	if LogLevelDebug >= e.logger.Level {
-		e.logger.printf(LogLevelDebug, e.Context, format, v...)
+		e.logger.printf(e.logger.Level, e.Context, format, v...)
 	}
 }
 
 // Infoln print info level logs in a line
 func (e *Entry) Infoln(msg string) {
 	if LogLevelInfo >= e.logger.Level {
-		e.logger.println(LogLevelInfo, e.Context, msg)
+		e.logger.println(e.Context, msg)
 	}
 }
 
 // Infof print info level logs in a specific format
 func (e *Entry) Infof(format string, v ...interface{}) {
 	if LogLevelInfo >= e.logger.Level {
-		e.logger.printf(LogLevelInfo, e.Context, format, v...)
+		e.logger.printf(e.logger.Level, e.Context, format, v...)
 	}
 }
 
 // Warnln print warn level logs in a line
 func (e *Entry) Warnln(msg string) {
 	if LogLevelWarn >= e.logger.Level {
-		e.logger.println(LogLevelWarn, e.Context, msg)
+		e.logger.println(e.Context, msg)
 	}
 }
 
 // Warnf print warn level logs in a specific format
 func (e *Entry) Warnf(format string, v ...interface{}) {
 	if LogLevelWarn >= e.logger.Level {
-		e.logger.printf(LogLevelWarn, e.Context, format, v...)
+		e.logger.printf(e.logger.Level, e.Context, format, v...)
 	}
 }
 
 // Errorln print error level logs in a line
 func (e *Entry) Errorln(msg string) {
 	if LogLevelError >= e.logger.Level {
-		e.logger.println(LogLevelError, e.Context, msg)
+		e.logger.println(e.Context, msg)
 	}
 }
 
 // Errorf print error level logs in a specific format
 func (e *Entry) Errorf(format string, v ...interface{}) {
 	if LogLevelError >= e.logger.Level {
-		e.logger.printf(LogLevelError, e.Context, format, v...)
+		e.logger.printf(e.logger.Level, e.Context, format, v...)
 	}
 }
 
 // Fatalln print fatal level logs in a line
 func (e *Entry) Fatalln(msg string) {
 	if LogLevelFatal >= e.logger.Level {
-		e.logger.println(LogLevelFatal, e.Context, msg)
+		e.logger.println(e.Context, msg)
 		os.Exit(1)
 	}
 }
@@ -116,7 +116,7 @@ func (e *Entry) Fatalln(msg string) {
 // Fatalf print fatal level logs in a specific format
 func (e *Entry) Fatalf(format string, v ...interface{}) {
 	if LogLevelFatal >= e.logger.Level {
-		e.logger.printf(LogLevelFatal, e.Context, format, v...)
+		e.logger.printf(e.logger.Level, e.Context, format, v...)
 		os.Exit(1)
 	}
 }

--- a/log.go
+++ b/log.go
@@ -72,6 +72,7 @@ func NewLogger(writer io.Writer, level, caller int) *Logger {
 		logger = &Logger{
 			Writer:    writer,
 			Level:     level,
+			LevelStr:  getLogLevel(level),
 			CallPath:  caller,
 			formatter: &TextFormatter{},
 		}

--- a/logger.go
+++ b/logger.go
@@ -116,19 +116,10 @@ func (l *Logger) doPrint(level int, ctx Context, format string, v ...interface{}
 }
 
 func (l *Logger) doPrintln(ctx Context, format string, msg string) {
-	fields := &Fields{
-		Timestamp: getTimestamp(),
-		Level:     l.LevelStr,
-		Msg:       msg,
-	}
-
 	// TODO: make functions meta a optional argument
 	// fields.File, fields.Func, fields.Line = getFuncInfo(l.CallPath)
 
-	// this is core print functions
-	// data := l.formatter.Print(fields, ctx)
-
-	fmt.Fprintf(l.Writer, "%s [%s] %s\n", fields.Timestamp, fields.Level, msg)
+	fmt.Fprintf(l.Writer, "%s [%s] %s\n", getTimestamp(), l.LevelStr, msg)
 }
 
 func (l *Logger) println(ctx Context, msg string) {

--- a/logger.go
+++ b/logger.go
@@ -126,15 +126,16 @@ func (l *Logger) doPrintln(ctx Context, format string, msg string) {
 	// fields.File, fields.Func, fields.Line = getFuncInfo(l.CallPath)
 
 	// this is core print functions
-	data := l.formatter.Print(fields, ctx)
-	fmt.Fprintln(l.Writer, data)
+	// data := l.formatter.Print(fields, ctx)
+
+	fmt.Fprintf(l.Writer, "%s [%s] %s\n", fields.Timestamp, fields.Level, msg)
 }
 
-func (l *Logger) println(level int, ctx Context, msg string) {
+func (l *Logger) println(ctx Context, msg string) {
 	if l.Async {
-		go l.doPrintln(level, ctx, "", msg)
+		go l.doPrintln(ctx, "", msg)
 	} else {
-		l.doPrintln(level, ctx, "", msg)
+		l.doPrintln(ctx, "", msg)
 	}
 }
 
@@ -151,77 +152,77 @@ type Context map[string]string
 // Traceln print trace level logs in a line
 func (l *Logger) Traceln(msg string) {
 	if LogLevelTrace >= logger.Level {
-		l.println(LogLevelTrace, Context{}, msg)
+		l.println(Context{}, msg)
 	}
 }
 
 // Tracef print trace level logs in a specific format
 func (l *Logger) Tracef(format string, v ...interface{}) {
 	if LogLevelTrace >= logger.Level {
-		l.printf(LogLevelTrace, Context{}, format, v...)
+		l.printf(logger.Level, Context{}, format, v...)
 	}
 }
 
 // Debugln print debug level logs in a line
 func (l *Logger) Debugln(msg string) {
 	if LogLevelDebug >= logger.Level {
-		l.println(LogLevelDebug, Context{}, msg)
+		l.println(Context{}, msg)
 	}
 }
 
 // Debugf print debug level logs in a specific format
 func (l *Logger) Debugf(format string, v ...interface{}) {
 	if LogLevelDebug >= logger.Level {
-		l.printf(LogLevelDebug, Context{}, format, v...)
+		l.printf(logger.Level, Context{}, format, v...)
 	}
 }
 
 // Infoln print info level logs in a line
 func (l *Logger) Infoln(msg string) {
 	if LogLevelInfo >= logger.Level {
-		l.println(LogLevelInfo, Context{}, msg)
+		l.println(Context{}, msg)
 	}
 }
 
 // Infof print info level logs in a specific format
 func (l *Logger) Infof(format string, v ...interface{}) {
 	if LogLevelInfo >= logger.Level {
-		l.printf(LogLevelInfo, Context{}, format, v...)
+		l.printf(logger.Level, Context{}, format, v...)
 	}
 }
 
 // Warnln print warn level logs in a line
 func (l *Logger) Warnln(msg string) {
 	if LogLevelWarn >= logger.Level {
-		l.println(LogLevelWarn, Context{}, msg)
+		l.println(Context{}, msg)
 	}
 }
 
 // Warnf print warn level logs in a specific format
 func (l *Logger) Warnf(format string, v ...interface{}) {
 	if LogLevelWarn >= logger.Level {
-		l.printf(LogLevelWarn, Context{}, format, v...)
+		l.printf(logger.Level, Context{}, format, v...)
 	}
 }
 
 // Errorln print error level logs in a line
 func (l *Logger) Errorln(msg string) {
 	if LogLevelError >= logger.Level {
-		l.println(LogLevelError, Context{}, msg)
+		l.println(Context{}, msg)
 	}
 }
 
 // Errorf print error level logs in a specific format
 func (l *Logger) Errorf(format string, v ...interface{}) {
 	if LogLevelError >= logger.Level {
-		l.printf(LogLevelError, Context{}, format, v...)
+		l.printf(logger.Level, Context{}, format, v...)
 	}
 }
 
 // Fatalln print fatal level logs in a line
 func (l *Logger) Fatalln(msg string) {
 	if LogLevelFatal >= logger.Level {
-		l.println(LogLevelFatal, Context{}, msg)
+		l.println(Context{}, msg)
 		os.Exit(1)
 	}
 }
@@ -229,7 +230,7 @@ func (l *Logger) Fatalln(msg string) {
 // Fatalf print fatal level logs in a specific format
 func (l *Logger) Fatalf(format string, v ...interface{}) {
 	if LogLevelFatal >= logger.Level {
-		l.printf(LogLevelFatal, Context{}, format, v...)
+		l.printf(logger.Level, Context{}, format, v...)
 		os.Exit(1)
 	}
 }

--- a/logger.go
+++ b/logger.go
@@ -30,7 +30,9 @@ type Logger struct {
 	formatter Formatter
 	entries   sync.Pool
 
-	Level    int
+	Level int
+	// TODO: remove this later
+	LevelStr string
 	CallPath int
 	Async    bool
 	// Sink     Sink
@@ -72,6 +74,7 @@ func (l *Logger) SetLevel(level int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.Level = level
+	l.LevelStr = getLogLevel(level)
 }
 
 // SetLevelByName set the log level by name
@@ -112,10 +115,10 @@ func (l *Logger) doPrint(level int, ctx Context, format string, v ...interface{}
 	fmt.Fprintln(l.Writer, msg)
 }
 
-func (l *Logger) doPrintln(level int, ctx Context, format string, msg string) {
+func (l *Logger) doPrintln(ctx Context, format string, msg string) {
 	fields := &Fields{
 		Timestamp: getTimestamp(),
-		Level:     getLogLevel(level),
+		Level:     l.LevelStr,
 		Msg:       msg,
 	}
 


### PR DESCRIPTION
* feat: introduce a member LevelStr to Logger
* refactor: remove parameter level from every Println
* feat: remove Fields and merge prints

before:
```shell
BenchmarkEvent/Mlog-12            	 2094327	       580.2 ns/op	    1009 B/op	      16 allocs/op
```
after:
```shell
BenchmarkEvent/Mlog-12            	 9991424	       117.7 ns/op	     120 B/op	       5 allocs/op
```