### PR TITLE
refactor: using sync Pool buf and writer instead of Fprintf

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -115,19 +115,33 @@ func (l *Logger) doPrint(level int, ctx Context, format string, v ...interface{}
 	fmt.Fprintln(l.Writer, msg)
 }
 
+type LogEntry struct {
+	buf []byte
+}
+
+var lepool = sync.Pool{
+	New: func() any {
+		return &LogEntry{
+			buf: make([]byte, 1024),
+		}
+	},
+}
+
 func (l *Logger) doPrintln(ctx Context, msg string) {
 	// TODO: make functions meta a optional argument
 	// fields.File, fields.Func, fields.Line = getFuncInfo(l.CallPath)
 
-	var buf = []byte{}
-	buf = append(buf, getTimestamp()...)
-	buf = append(buf, " ["...)
-	buf = append(buf, l.LevelStr...)
-	buf = append(buf, "] "...)
-	buf = append(buf, msg...)
-	buf = append(buf, '\n')
+	e := lepool.Get().(*LogEntry)
+	defer lepool.Put(e)
 
-	_, _ = l.Writer.Write(buf)
+	e.buf = append(e.buf, getTimestamp()...)
+	e.buf = append(e.buf, " ["...)
+	e.buf = append(e.buf, l.LevelStr...)
+	e.buf = append(e.buf, "] "...)
+	e.buf = append(e.buf, msg...)
+	e.buf = append(e.buf, '\n')
+
+	_, _ = l.Writer.Write(e.buf)
 }
 
 func (l *Logger) println(ctx Context, msg string) {

--- a/logger.go
+++ b/logger.go
@@ -115,18 +115,26 @@ func (l *Logger) doPrint(level int, ctx Context, format string, v ...interface{}
 	fmt.Fprintln(l.Writer, msg)
 }
 
-func (l *Logger) doPrintln(ctx Context, format string, msg string) {
+func (l *Logger) doPrintln(ctx Context, msg string) {
 	// TODO: make functions meta a optional argument
 	// fields.File, fields.Func, fields.Line = getFuncInfo(l.CallPath)
 
-	fmt.Fprintf(l.Writer, "%s [%s] %s\n", getTimestamp(), l.LevelStr, msg)
+	var buf = []byte{}
+	buf = append(buf, getTimestamp()...)
+	buf = append(buf, " ["...)
+	buf = append(buf, l.LevelStr...)
+	buf = append(buf, "] "...)
+	buf = append(buf, msg...)
+	buf = append(buf, '\n')
+
+	_, _ = l.Writer.Write(buf)
 }
 
 func (l *Logger) println(ctx Context, msg string) {
 	if l.Async {
-		go l.doPrintln(ctx, "", msg)
+		go l.doPrintln(ctx, msg)
 	} else {
-		l.doPrintln(ctx, "", msg)
+		l.doPrintln(ctx, msg)
 	}
 }
 


### PR DESCRIPTION
Allocations per operation have been reduced to 2 from 5.

before:
```shell
BenchmarkEvent/Mlog-12            	 9991424	       117.7 ns/op	     120 B/op	       5 allocs/op
```

after:
```shell
BenchmarkEvent/Mlog-12            	10043523	       102.8 ns/op	     470 B/op	       2 allocs/op
```