### PR TITLE
refactor: add buf clear before using

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -134,11 +134,14 @@ func (l *Logger) doPrintln(ctx Context, msg string) {
 	// fields.File, fields.Func, fields.Line = getFuncInfo(l.CallPath)
 
 	e := lepool.Get().(*LogEntry)
+	e.buf = e.buf[:0]
 	defer lepool.Put(e)
 
 	e.buf = append(e.buf, time.Now().Format(TimeFormatDefault)...)
 	e.buf = append(e.buf, '[')
+	e.buf = append(e.buf, l.LevelStr...)
 	e.buf = append(e.buf, ']')
+	e.buf = append(e.buf, msg...)
 	e.buf = append(e.buf, '\n')
 
 	_, _ = l.Writer.Write(e.buf)


### PR DESCRIPTION
Allocated memory size reduced from 470 B/op to 72 B/op.

before:
```shell
BenchmarkEvent/Mlog-12            	10043523	       102.8 ns/op	     470 B/op	       2 allocs/op
```

after:
```shell
BenchmarkEvent/Mlog-12            	15831369	        85.07 ns/op	      72 B/op	       2 allocs/op
```